### PR TITLE
Config cache & keys in config definition

### DIFF
--- a/src/EscolaLmsSettingsServiceProvider.php
+++ b/src/EscolaLmsSettingsServiceProvider.php
@@ -37,7 +37,9 @@ class EscolaLmsSettingsServiceProvider extends ServiceProvider
             $this->bootForConsole();
         }
 
-        AdministrableConfig::loadConfigFromDatabase();
+        if (!AdministrableConfig::loadConfigFromCache()) {
+            AdministrableConfig::loadConfigFromDatabase();
+        }
     }
 
     public function register()

--- a/src/Facades/AdministrableConfig.php
+++ b/src/Facades/AdministrableConfig.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static bool  registerConfig(string $key, array $rules = ['required'], bool $public = true, bool $readonly = false)
  * @method static bool  storeConfig()
+ * @method static bool  loadConfigFromCache()
  * @method static bool  loadConfigFromDatabase()
  * @method static array getPublicConfig()
  * @method static array getConfig(string $key = null)

--- a/src/Services/AdministrableConfigService.php
+++ b/src/Services/AdministrableConfigService.php
@@ -22,7 +22,8 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
     public function registerConfig(string $key, array $rules = [], bool $public = true, bool $readonly = false): bool
     {
         $this->administrableConfig[$key] = [
-            'key' => $key,
+            'full_key' => $key,
+            'key' => Str::after($key, '.'),
             'rules' => $rules,
             'public' => $public,
             'readonly' => $readonly,

--- a/src/Services/AdministrableConfigService.php
+++ b/src/Services/AdministrableConfigService.php
@@ -7,6 +7,7 @@ use EscolaLms\Settings\Services\Contracts\AdministrableConfigServiceContract;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Validator;
@@ -14,11 +15,14 @@ use Illuminate\Validation\ValidationException;
 
 class AdministrableConfigService implements AdministrableConfigServiceContract
 {
+    const CACHE_KEY = 'escolalms_config_cache';
+
     private array $administrableConfig = [];
 
     public function registerConfig(string $key, array $rules = [], bool $public = true, bool $readonly = false): bool
     {
         $this->administrableConfig[$key] = [
+            'key' => $key,
             'rules' => $rules,
             'public' => $public,
             'readonly' => $readonly,
@@ -28,9 +32,12 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
 
     public function storeConfig(): bool
     {
+        $this->storeConfigInCache();
+
         if (Config::get('escola_settings.use_database')) {
             return $this->saveConfigToDatabase();
         }
+
         return $this->saveConfigToFiles();
     }
 
@@ -65,12 +72,21 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
 
     private function saveConfigToDatabase(): bool
     {
-        $keys = $this->getNotReadonlyKeys();
-        $config = $this->mapKeysToConfigValues($keys);
-
-        $configModel = ModelsConfig::query()->updateOrCreate(['id' => 1], ['value' => $config]);
+        $configModel = ModelsConfig::query()->updateOrCreate(['id' => 1], ['value' => $this->getWritableConfig()]);
 
         return $configModel->exists;
+    }
+
+    public function loadConfigFromCache(bool $forced = false): bool
+    {
+        if (Config::get('escola_settings.use_database', false) || $forced) {
+            $cache = $this->getConfigFromCache();
+            if (!empty($cache)) {
+                Config::set($cache);
+                return true;
+            }
+        }
+        return false;
     }
 
     public function loadConfigFromDatabase(bool $forced = false): bool
@@ -114,6 +130,8 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
             $key_with_dot = str_replace('__', '.', $key);
             Config::set($key_with_dot, $value);
         }
+
+        $this->storeConfigInCache();
     }
 
     public function getConfig(string $key = null): array
@@ -133,6 +151,16 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
         return $this->undot(array_merge($this->administrableConfig[$key], ['value' => Config::get($key)]));
     }
 
+    private function getConfigFromCache(): array
+    {
+        return Cache::get(self::CACHE_KEY, []);
+    }
+
+    private function storeConfigInCache(): void
+    {
+        Cache::forever(self::CACHE_KEY, $this->getWritableConfig());
+    }
+
     public function getPublicConfig(): array
     {
         return $this->undot($this->mapKeysToConfigValues($this->getPublicKeys()));
@@ -141,6 +169,11 @@ class AdministrableConfigService implements AdministrableConfigServiceContract
     private function getPublicKeys(): array
     {
         return array_keys(array_filter($this->administrableConfig, fn ($config) => $config['public']));
+    }
+
+    private function getWritableConfig(): array
+    {
+        return $this->mapKeysToConfigValues($this->getNotReadonlyKeys());
     }
 
     private function getNotReadonlyKeys(): array

--- a/src/Services/Contracts/AdministrableConfigServiceContract.php
+++ b/src/Services/Contracts/AdministrableConfigServiceContract.php
@@ -11,7 +11,10 @@ interface AdministrableConfigServiceContract
 
     public function getConfig(string $key = null): array;
     public function getPublicConfig(): array;
+
+    public function loadConfigFromCache(): bool;
     public function loadConfigFromDatabase(): bool;
+
     public function setConfig(array $config): void;
     public function storeConfig(): bool;
 }

--- a/tests/API/ConfigApiTest.php
+++ b/tests/API/ConfigApiTest.php
@@ -59,6 +59,7 @@ class ConfigApiTest extends TestCase
             'data' => [
                 'test_config_file' => [
                     'test_key' => [
+                        'key' => 'test_config_file.test_key',
                         'rules' => [
                             'required',
                             'string'
@@ -68,6 +69,7 @@ class ConfigApiTest extends TestCase
                         'public' => false,
                     ],
                     'test_key2' => [
+                        'key' => 'test_config_file.test_key2',
                         'rules' => [
                             'required',
                             'string'
@@ -131,6 +133,7 @@ class ConfigApiTest extends TestCase
             'data' => [
                 'test_config_file' => [
                     'test_key' => [
+                        'key' => 'test_config_file.test_key',
                         'rules' => [
                             'required',
                             'string'
@@ -140,6 +143,7 @@ class ConfigApiTest extends TestCase
                         'public' => false,
                     ],
                     'test_key2' => [
+                        'key' => 'test_config_file.test_key2',
                         'rules' => [
                             'required',
                             'string'

--- a/tests/API/ConfigApiTest.php
+++ b/tests/API/ConfigApiTest.php
@@ -59,7 +59,8 @@ class ConfigApiTest extends TestCase
             'data' => [
                 'test_config_file' => [
                     'test_key' => [
-                        'key' => 'test_config_file.test_key',
+                        'full_key' => 'test_config_file.test_key',
+                        'key' => 'test_key',
                         'rules' => [
                             'required',
                             'string'
@@ -69,7 +70,8 @@ class ConfigApiTest extends TestCase
                         'public' => false,
                     ],
                     'test_key2' => [
-                        'key' => 'test_config_file.test_key2',
+                        'full_key' => 'test_config_file.test_key2',
+                        'key' => 'test_key2',
                         'rules' => [
                             'required',
                             'string'
@@ -133,7 +135,8 @@ class ConfigApiTest extends TestCase
             'data' => [
                 'test_config_file' => [
                     'test_key' => [
-                        'key' => 'test_config_file.test_key',
+                        'full_key' => 'test_config_file.test_key',
+                        'key' => 'test_key',
                         'rules' => [
                             'required',
                             'string'
@@ -143,7 +146,8 @@ class ConfigApiTest extends TestCase
                         'public' => false,
                     ],
                     'test_key2' => [
-                        'key' => 'test_config_file.test_key2',
+                        'full_key' => 'test_config_file.test_key2',
+                        'key' => 'test_key2',
                         'rules' => [
                             'required',
                             'string'


### PR DESCRIPTION
- Cache config when using database as storage
- Add dotted keys to config definition (for easier handling of nested config values in frontend)